### PR TITLE
Add argument --splits for splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ api_info.py
 __pycache__
 src/config.yaml
 
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tfrecord/
 api_info.py
 *.swp
 *~
+__pycache__
+src/config.yaml
+

--- a/README.md
+++ b/README.md
@@ -53,4 +53,11 @@ To split data into two groups, with 30% in the first and 70% in the second, whil
 `python convert.py --download --split 30 70`
 
 
+# Tests
 
+To run the tests:
+
+```
+cd src
+python -m unittest
+```

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,0 @@
-__pycache__/*
-labelbox/*
-tfrecord/*
-config.yaml
-

--- a/src/test/test_convert.py
+++ b/src/test/test_convert.py
@@ -4,14 +4,11 @@ import sys
 import unittest
 import convert
 
+# TODO convert to pytest
 class TestConvert(unittest.TestCase):
-#[20,30], 10
-#[20,30], 100
-#[50,30,20], 2
-#[1,99], 2
     def test_split_small_list(self):
         result = convert.splits_to_record_indices([20, 30, 50], 2)
-        self.assertEqual(result, [1])
+        self.assertEqual(result, [1, 2])
 
     def test_split_single(self):
         result = convert.splits_to_record_indices([100], 1000)
@@ -25,5 +22,13 @@ class TestConvert(unittest.TestCase):
         self.assertEqual(result, [1000])
 
     def test_split_happy(self):
-        result = convert.splits_to_record_indices([20, 30], 100)
+        result = convert.splits_to_record_indices([20, 30, 50], 100)
         self.assertEqual(result, [20, 50, 100])
+
+    def test_split_ten(self):
+        result = convert.splits_to_record_indices([20, 30, 50], 10)
+        self.assertEqual(result, [2, 5, 10])
+
+    def test_split_last_split_rounded_down(self):
+        result = convert.splits_to_record_indices([30, 70], 675)
+        self.assertEqual(result, [202, 675])

--- a/src/test/test_convert.py
+++ b/src/test/test_convert.py
@@ -1,0 +1,29 @@
+# vim:ts=4:sw=4:sts=4
+
+import sys
+import unittest
+import convert
+
+class TestConvert(unittest.TestCase):
+#[20,30], 10
+#[20,30], 100
+#[50,30,20], 2
+#[1,99], 2
+    def test_split_small_list(self):
+        result = convert.splits_to_record_indices([20, 30, 50], 2)
+        self.assertEqual(result, [1])
+
+    def test_split_single(self):
+        result = convert.splits_to_record_indices([100], 1000)
+        self.assertEqual(result, [1000])
+
+    def test_split_empty(self):
+        result = convert.splits_to_record_indices([], 1000)
+        self.assertEqual(result, [1000])
+
+        result = convert.splits_to_record_indices(None, 1000)
+        self.assertEqual(result, [1000])
+
+    def test_split_happy(self):
+        result = convert.splits_to_record_indices([20, 30], 100)
+        self.assertEqual(result, [20, 50, 100])


### PR DESCRIPTION
This adds an argument --split that takes a whitespace separated list of percentages to use to split the resulting data into multiple TFRecord files. The percentages should add up to less than or equal to 100.