### PR TITLE
Add id/url data to tfrecords; Dockerize (for usage and for dev)

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "dockerFile": "Dockerfile",
+
+    "extensions": [
+        "ms-python.python", "ms-python.vscode-pylance", "ms-azuretools.vscode-docker",
+    ],
+
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 src/config.yaml
 
 .idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM tensorflow/tensorflow:1.15.2-py3
+# To switch to TensorFlow 2, change the above to a TensorFlow 2 image.
+# You will also have to change the tf1/setup.py reference below to use tf2/setup.py
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    git \
+    protobuf-compiler
+
+RUN python -m pip install -U pip
+
+COPY requirements.txt requirements.txt
+RUN python -m pip install -r requirements.txt
+
+# Currently using xdhmoore's repo to ensure compatibility for xdhmoore's stuff. Uncomment to use the main repo instead,
+# Though it's probably advisable to pin to a specific commit, not master (since master changes often)
+# RUN git clone --branch master --single-branch https://github.com/tensorflow/models.git /tfmodels
+RUN git clone --branch lb2tf --single-branch https://github.com/xdhmoore/models.git /tfmodels
+
+RUN cp /tfmodels/research/object_detection/packages/tf1/setup.py /tfmodels/research/
+RUN cd /tfmodels/research/ && protoc object_detection/protos/*.proto --python_out=.
+RUN cd /tfmodels/research && python -m pip install .
+
+# Add new user to avoid running as root
+RUN useradd -ms /bin/bash labelboxtotfrecord
+
+USER labelboxtotfrecord
+WORKDIR /home/labelboxtotfrecord/src
+
+# TODO fix this so it doesn't copy api key?
+# The python code could also be changed to use environment variables
+COPY src /home/labelboxtotfrecord/src
+
+VOLUME ["/data"]
+
+ENTRYPOINT [ "python3", "/home/labelboxtotfrecord/src/convert.py" ]
+CMD [ "--help" ]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Change the mount src to change where the data is downloaded to.
 
 *NOTE:* if you have downloaded a large amount of data in your project, when `docker build` runs it will copy the data as part of the context which may take a long time. To avoid this, either move downloaded data outside of the project folder before doing a build, use mount settings to save the data outside the project folder to begin with, or use a dockerignore file to ignore the data once downloaded.
 
+If you encounter permissions denied errors, check to see that docker hasn't created the `data` directory as root. `chown` or recreate the directory yourself to fix.
+
 ## Usage:
 
     usage: convert.py [-h] [--puid PUID] [--api-key API_KEY]
@@ -48,6 +50,7 @@ Change the mount src to change where the data is downloaded to.
                         of Labelbox labels.
       --tfrecord-dest TFRECORD_DEST
                         Destination folder for downloaded images
+      --limit LIMIT         Only retrieve and convert the first LIMIT data items
       --splits SPLITS [SPLITS ...]
                         Space-separated list of integer percentages for
                         splitting the output into multiple TFRecord files

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Then run
 
 ### Docker Setup using Tensorflow 1:
 
+Assuming you have a config.yaml file set up (see Examples section):
+
 ```
 # From project root
 docker build -t lb2tf .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
 # LabelboxToTFRecord
 Convert Labelbox style json files to TFRecord file format (.tfrecord files) so the data can be used with TensorFlow.
 
+## Installation
+
+### Python Installation using Tensorflow 2:
 You must have TensorFlow's Object Detection API installed, directions for installation can be found here: https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf2.md
+
+Then run
+
+`python3 -m pip install -r requirements.txt`
+
+### Docker Setup using Tensorflow 1:
+
+```
+# From project root
+docker build -t lb2tf .
+mkdir data
+
+# This will run convert.py, downloading the data to a ./data folder
+docker run --mount "type=bind,src=${PWD}/data,dst=/data" lb2tf --split 80 20 --download --labelbox-dest /data/labelbox --tfrecord-dest /data/tfrecord
+```
+Change the mount src to change where the data is downloaded to.
+
+*NOTE:* if you have downloaded a large amount of data in your project, when `docker build` runs it will copy the data as part of the context which may take a long time. To avoid this, either move downloaded data outside of the project folder before doing a build, use mount settings to save the data outside the project folder to begin with, or use a dockerignore file to ignore the data once downloaded.
 
 ## Usage:
 
@@ -51,7 +72,6 @@ To split data into two groups, with 30% in the first and 70% in the second...
 To split data into two groups, with 30% in the first and 70% in the second, while downloading images locally...
 
 `python convert.py --download --split 30 70`
-
 
 # Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pandas==1.1.0
 labelbox==2.4.3
 PyYAML==5.3.1
 progressbar==2.5
-
+pillow==7.2.0

--- a/src/convert.py
+++ b/src/convert.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import os
 import io
 import sys
-import pandas as pd
 import tensorflow as tf
 import glob
 import xml.etree.ElementTree as ET
@@ -68,6 +67,9 @@ def create_tf_example(record_obj, class_dict):
         'image/object/bbox/ymin': dataset_util.float_list_feature(ymins),
         'image/object/bbox/ymax': dataset_util.float_list_feature(ymaxs),
         'image/object/class/text': dataset_util.bytes_list_feature(classes_text),
+        'image/key/sha256': dataset_util.bytes_feature(record_obj.sha_key.encode('utf8')),
+        'image/labelbox/datarow_id': dataset_util.bytes_feature(record_obj.labelbox_rowid.encode('utf8')),
+        'images/labelbox/view_url': dataset_util.bytes_feature(record_obj.labelbox_url.encode('utf8')),
         'image/object/class/label': dataset_util.int64_list_feature(classes),
     }))
     return tf_example

--- a/src/convert.py
+++ b/src/convert.py
@@ -17,8 +17,8 @@ import progressbar
 from datetime import datetime
 from pathlib import Path
 from PIL import Image
-from object_detection.utils import dataset_util
 
+from object_detection.utils import dataset_util
 from object_detection.protos import string_int_label_map_pb2
 from google.protobuf import text_format
 
@@ -99,8 +99,8 @@ def splits_to_record_indices(splits, num_records):
     # Dedupe
     return list(OrderedDict.fromkeys(img_indices))
 
-def generate_records(puid, api_key, labelbox_dest, tfrecord_dest, splits, download):
-    data, records = parse_labelbox.parse_labelbox_data(puid, api_key, labelbox_dest, download)
+def generate_records(puid, api_key, labelbox_dest, tfrecord_dest, splits, download, limit):
+    data, records = parse_labelbox.parse_labelbox_data(puid, api_key, labelbox_dest, download, limit)
     print("Creating .tfrecord files")
     class_dict = parse_labelbox.get_classes_from_labelbox(data)
     tfrecord_folder = tfrecord_dest
@@ -113,14 +113,15 @@ def generate_records(puid, api_key, labelbox_dest, tfrecord_dest, splits, downlo
     splits = splits_to_record_indices(splits, len(records))
     assert splits[-1] == len(records), f'{splits}, {len(records)}'
 
+    # TODO use a seed-based random so it's the same every time
+    random.shuffle(records)
+
     split_start = 0
     print(f'Creating {len(splits)} TFRecord files:')
     for split_end in splits:
         outfile = f'{puid}_{strnow}_{split_end - split_start}.tfrecord'
         outpath = tfrecord_folder + outfile
         with tf.io.TFRecordWriter(outpath) as writer:
-            # TODO use a seed-based random so it's the same every time
-            random.shuffle(records)
             for record in records[split_start:split_end]:
                 tf_example = create_tf_example(record, class_dict)
                 writer.write(tf_example.SerializeToString())
@@ -159,6 +160,7 @@ if __name__ == '__main__':
     parser.add_argument('--api-key', help="API key associated with your Labelbox account")
     parser.add_argument('--labelbox-dest', help="Destination folder for downloaded images and json file of Labelbox labels.", default="labelbox")
     parser.add_argument('--tfrecord-dest', help="Destination folder for .tfrecord file(s)", default="tfrecord")
+    parser.add_argument('--limit', help="Only retrieve and convert the first N data items", type=int, default=2**1000)
     parser.add_argument('--splits', help="Space-separated list of integer percentages for splitting the " +
         "output into multiple TFRecord files instead of one. Sum of values should be <=100. " +
         "Example: '--splits 10 70' will write 3 files with 10%%, 70%%, and 20%% of the data, respectively",
@@ -176,7 +178,7 @@ if __name__ == '__main__':
     api_key = args.api_key or config['api_key']
     splits = validate_splits(args.splits)
 
-    generate_records(puid, api_key, args.labelbox_dest, args.tfrecord_dest, splits, args.download)
+    generate_records(puid, api_key, args.labelbox_dest, args.tfrecord_dest, splits, args.download, args.limit)
 
     
 

--- a/src/convert.py
+++ b/src/convert.py
@@ -160,7 +160,7 @@ if __name__ == '__main__':
     parser.add_argument('--api-key', help="API key associated with your Labelbox account")
     parser.add_argument('--labelbox-dest', help="Destination folder for downloaded images and json file of Labelbox labels.", default="labelbox")
     parser.add_argument('--tfrecord-dest', help="Destination folder for .tfrecord file(s)", default="tfrecord")
-    parser.add_argument('--limit', help="Only retrieve and convert the first N data items", type=int, default=2**1000)
+    parser.add_argument('--limit', help="Only retrieve and convert the first LIMIT data items", type=int, default=2**1000)
     parser.add_argument('--splits', help="Space-separated list of integer percentages for splitting the " +
         "output into multiple TFRecord files instead of one. Sum of values should be <=100. " +
         "Example: '--splits 10 70' will write 3 files with 10%%, 70%%, and 20%% of the data, respectively",

--- a/src/parse_labelbox.py
+++ b/src/parse_labelbox.py
@@ -12,21 +12,25 @@ import tensorflow as tf
 import label
 import time
 import progressbar
+import hashlib
 
 #contains all of the necessary info to create a tfrecord
 class TFRecordInfo:
 
-    def __init__(self, height, width, filename, source_id, encoded, format, labels):
+    def __init__(self, height, width, filename, source_id, encoded, format, sha_key, labelbox_rowid, labelbox_url, labels):
         self.height = height
         self.width = width
         self.filename = filename
         self.source_id = source_id
         self.encoded = encoded
         self.format = format
+        self.sha_key = sha_key
+        self.labelbox_rowid = labelbox_rowid
+        self.labelbox_url = labelbox_url
         self.labels = labels
 
     def __repr__(self):
-        return "TFRecordInfo({0}, {1}, {2}, {3}, {4}, {5}, {6})".format(self.height, self.width, self.filename, self.source_id, type(self.encoded), self.format, self.labels)
+        return "TFRecordInfo({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(self.height, self.width, self.filename, self.source_id, type(self.encoded), self.format, self.sha_key, self.labelbox_rowid, self.labels)
 
 #download data and create a list of img_obj dictionaries from labelbox json format
 def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download):
@@ -38,41 +42,56 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download):
         print("--download flag detected")
         print("Downloading images locally to labelbox/images")
     bar = progressbar.ProgressBar(maxval=len(data), \
-    widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
+        widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
     bar.start()
     for i in range(len(data)):
         record = data[i]
-        jpg_url = record["Labeled Data"]
-        temp = urlparse(jpg_url)
-        image_name = temp.path
-        image_name = image_name[1:]
-        if not os.path.exists(labelbox_dest):
-            os.makedirs(labelbox_dest)
-        if labelbox_dest[len(labelbox_dest)-1] != '/':
-            labelbox_dest += '/'
 
-        if download:
-            if not os.path.exists(labelbox_dest+"images"):
-                os.makedirs(labelbox_dest+"images")
-            outpath = labelbox_dest+"images/"+image_name
-            if not path.exists(outpath):
-                jpg = urllib.request.urlretrieve(jpg_url, outpath)
-            with tf.io.gfile.GFile(outpath, 'rb') as fid:
-                encoded_jpg = fid.read()
-                im = Image.open(outpath)
-                width, height = im.size
-        else:
-            outpath = ""
-            with urllib.request.urlopen(jpg_url) as url:
-                encoded_jpg = io.BytesIO(url.read()).read()
-                im = Image.open(io.BytesIO(encoded_jpg))
-                width, height = im.size
-        labels = list()
+        # TODO Maybe we want some images without labels
         if "objects" in record["Label"]:
+
+            jpg_url = record["Labeled Data"]
+            temp = urlparse(jpg_url)
+            # This seems to be the org id + guid (image specific for storage purposes?) + external id (which is the original filename)
+            #image_name = temp.path[1:]
+            # TODO what if external id isn't defined...
+            # DataRow ID seems to be what is used on the Labels tab anyway...
+            image_name = f"{record['ID']}-{record['DataRow ID']}-{record['External ID']}"
+            if not os.path.exists(labelbox_dest):
+                os.makedirs(labelbox_dest)
+            if labelbox_dest[len(labelbox_dest)-1] != '/':
+                labelbox_dest += '/'
+
+            if download:
+                if not os.path.exists(labelbox_dest+"images"):
+                    os.makedirs(labelbox_dest+"images")
+                outpath = labelbox_dest+"images/"+image_name
+                if not path.exists(outpath):
+                    jpg = urllib.request.urlretrieve(jpg_url, outpath)
+                with tf.io.gfile.GFile(outpath, 'rb') as fid:
+                    encoded_jpg = fid.read()
+                    im = Image.open(outpath)
+                    width, height = im.size
+            else:
+                # TODO use record["External ID"], which appears to be filename?
+                outpath = ""
+                with urllib.request.urlopen(jpg_url) as url:
+                    # TODO Not sure if this matters. I think this maybe could be one less read, like:
+                    # encoded_jpg = url.read()
+                    # im = Image.open(io.BytesIO(encoded_jpg))
+                    encoded_jpg = io.BytesIO(url.read()).read()
+                    im = Image.open(io.BytesIO(encoded_jpg))
+                    width, height = im.size
+
+            sha_key = hashlib.sha256(encoded_jpg).hexdigest()
+
+            labels = list()
             label_objs = record["Label"]["objects"]
             for l in label_objs:
                 labels.append(label.label_from_labelbox_obj(l))
-            records.append(TFRecordInfo(height, width, outpath, outpath, encoded_jpg, image_format, labels))
+            records.append(TFRecordInfo(height, width, outpath, outpath, encoded_jpg, image_format, sha_key, record["DataRow ID"], record["View Label"], labels))
+        else:
+            print(f"DataRow {record['DataRow ID']} has no labels. Skipping. See more at {record['View Label']}\n")
         bar.update(i+1)
     bar.finish()
     return data, records

--- a/src/parse_labelbox.py
+++ b/src/parse_labelbox.py
@@ -33,7 +33,7 @@ class TFRecordInfo:
         return "TFRecordInfo({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})".format(self.height, self.width, self.filename, self.source_id, type(self.encoded), self.format, self.sha_key, self.labelbox_rowid, self.labels)
 
 #download data and create a list of img_obj dictionaries from labelbox json format
-def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download):
+def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download, limit):
     data = retrieve_data(project_unique_id, api_key, labelbox_dest)
     image_format = b'jpg'
     records = list()
@@ -41,10 +41,13 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download):
     if download:
         print("--download flag detected")
         print("Downloading images locally to labelbox/images")
-    bar = progressbar.ProgressBar(maxval=len(data), \
+    if len(data) > limit:
+        print ("--limit flag detected")
+        print(f"Found {len(data)} items but limiting to {limit}")
+    bar = progressbar.ProgressBar(maxval=min(len(data), limit), \
         widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
     bar.start()
-    for i in range(len(data)):
+    for i in range(min(len(data), limit)):
         record = data[i]
 
         # TODO Maybe we want some images without labels
@@ -94,6 +97,7 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download):
             print(f"DataRow {record['DataRow ID']} has no labels. Skipping. See more at {record['View Label']}\n")
         bar.update(i+1)
     bar.finish()
+    assert len(records) == min(len(data), limit)
     return data, records
 
 # def image_to_byte_array(image:Image):


### PR DESCRIPTION
I added 3 new fields to the TFRecords:
* `/image/key/sha256` - sha256 of image. I needed a unique id and object detection api uses this (or used to, anyway...). This sha also looks like it matches what you get by running `sha256sum` on one of the images saved with the `--download` flag, which could be handy for matching up tfrecord data with images.
* `/image/labelbox/datarow_id`- for helping trace back images to labelbox. There were several ids available and this seemed best...?
* `/image/labelbox/view_url` - for helping trace back images to labelbox

I also took the liberty of tweaking the logic so it doesn't download the image if it doesn't have any labels (before it downloaded the image but if there were no labels, it didn't do anything with it).

I also Dockerized the project. It can now be opened using the VS Code Remote Containers extension, and it will run the dockerfile and setup all the dependencies. Also, the convert script can be run outside VS Code via `docker run` now without having to install anything else. I added info to the README about running with Docker but the documentation is still a bit rough.

I realized you had used TensorFlow 2 in your setup instructions, while I'm using 1, so there's a discrepancy there. The Dockerfile has a couple comments about that, but I haven't actually tried it with TF2...