### PR TITLE
A bug fix and some changes to how source_id and filename are populated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Then run
 
 `python3 -m pip install -r requirements.txt`
 
-### Docker Setup using Tensorflow 1:
+### Docker Installation using Tensorflow 1:
 
 Assuming you have a config.yaml file set up (see Examples section):
 

--- a/src/convert.py
+++ b/src/convert.py
@@ -59,7 +59,7 @@ def create_tf_example(record_obj, class_dict):
         'image/height': dataset_util.int64_feature(record_obj.height),
         'image/width': dataset_util.int64_feature(record_obj.width),
         'image/filename': dataset_util.bytes_feature(filename),
-        'image/source_id': dataset_util.bytes_feature(filename),
+        'image/source_id': dataset_util.bytes_feature(record_obj.source_id.encode('utf8')),
         'image/encoded': dataset_util.bytes_feature(record_obj.encoded),
         'image/format': dataset_util.bytes_feature(image_format),
         'image/object/bbox/xmin': dataset_util.float_list_feature(xmins),

--- a/src/parse_labelbox.py
+++ b/src/parse_labelbox.py
@@ -48,6 +48,7 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download, lim
     bar = progressbar.ProgressBar(maxval=min(len(data), limit), \
         widgets=[progressbar.Bar('=', '[', ']'), ' ', progressbar.Percentage()])
     bar.start()
+    skipped = 0
     for i in range(min(len(data), limit)):
         record = data[i]
 
@@ -98,10 +99,15 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download, lim
             source_id = re.sub(r'\.','_', source_id)
             records.append(TFRecordInfo(height, width, record["External ID"], source_id, encoded_jpg, image_format, sha_key, record["DataRow ID"], record["View Label"], labels))
         else:
+            skipped += 1
             print(f"DataRow {record['DataRow ID']} has no labels. Skipping. See more at {record['View Label']}\n")
         bar.update(i+1)
     bar.finish()
-    assert len(records) == min(len(data), limit)
+
+    print(f"Found {len(data)} images:")
+    print(f"  Saved: {len(records)}")
+    print(f"  Skipped: {skipped}")
+
     return data, records
 
 # def image_to_byte_array(image:Image):

--- a/src/parse_labelbox.py
+++ b/src/parse_labelbox.py
@@ -13,6 +13,7 @@ import label
 import time
 import progressbar
 import hashlib
+import re
 
 #contains all of the necessary info to create a tfrecord
 class TFRecordInfo:
@@ -92,7 +93,10 @@ def parse_labelbox_data(project_unique_id, api_key, labelbox_dest, download, lim
             label_objs = record["Label"]["objects"]
             for l in label_objs:
                 labels.append(label.label_from_labelbox_obj(l))
-            records.append(TFRecordInfo(height, width, outpath, outpath, encoded_jpg, image_format, sha_key, record["DataRow ID"], record["View Label"], labels))
+
+            source_id = re.sub(r'\.(jpe?g|png)$', '', f"{record['DataRow ID']}-{record['External ID']}")
+            source_id = re.sub(r'\.','_', source_id)
+            records.append(TFRecordInfo(height, width, record["External ID"], source_id, encoded_jpg, image_format, sha_key, record["DataRow ID"], record["View Label"], labels))
         else:
             print(f"DataRow {record['DataRow ID']} has no labels. Skipping. See more at {record['View Label']}\n")
         bar.update(i+1)


### PR DESCRIPTION
Changes:

* Fix a bug in an assert statement that didn't account for skipped items
* Use LabelBox data row id + external id for the TFRecord source_id field
* Use the LabelBox external id for the TFRecord filename field instead of the full absolute original save path
* Print out how many saved/skipped at the end. 

I don't know if you care about these changes. They were mostly for me but I thought I'd pass them on in case they were useful. One reason you might not want them: this changes what is put into the the filename and source_id fields of the tfrecords and so could break code that depends on their values as they were set before.